### PR TITLE
feat: add resume subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Coach: ✅ Great explanation! You nailed the key insight—wrapped errors
 -   `learn-faster` - Launch Claude Code with FASTER coaching (auto-initializes on first run)
 -   `learn-faster init` - Force re-initialization or switch learning modes
 -   `learn-faster init --agent codex` - Initialize the project for Codex instead of Claude Code
+-   `learn-faster resume [<id>] [--pick] [--fork]` - Resume a previous coaching session (`--pick` to choose interactively; `--fork` to branch into a new session id)
 -   `learn-faster version` - Show current version
 
 ### Claude Code Slash Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,10 @@ Homepage = "https://github.com/cheukyin175/learn-faster-kit"
 Repository = "https://github.com/cheukyin175/learn-faster-kit"
 Issues = "https://github.com/cheukyin175/learn-faster-kit/issues"
 
-[tool.uv]
-dev-dependencies = []
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
 
 [tool.hatch.build]
 exclude = [

--- a/src/learn_faster/cli/launcher.py
+++ b/src/learn_faster/cli/launcher.py
@@ -3,11 +3,23 @@
 import json
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from learn_faster.cli.agents import DEFAULT_AGENT, AgentProfile, get_agent_profile
 from learn_faster.cli.paths import get_agent_templates_dir
 from learn_faster.cli.ui import print_dim, print_error, print_info
+
+
+ResumeMode = Literal["last", "id", "pick"]
+
+
+@dataclass(frozen=True)
+class ResumeTarget:
+    mode: ResumeMode
+    session_id: str | None = None
+    fork: bool = False
 
 
 def get_project_config() -> dict:
@@ -87,6 +99,63 @@ def launch_coach(auto_review: bool = False, initialize: bool = False) -> None:
         )
         sys.exit(1)
 
+    _run_agent(cmd, agent)
+
+
+def build_resume_command(
+    agent: AgentProfile, system_prompt: str, target: ResumeTarget
+) -> list[str]:
+    """Construct the resume command line for a given agent profile."""
+    if agent.name == "claude-code":
+        cmd = [agent.executable, "--system-prompt", system_prompt]
+        if target.mode == "last":
+            cmd.append("--continue")
+        elif target.mode == "id":
+            assert target.session_id is not None
+            cmd.extend(["--resume", target.session_id])
+        else:
+            cmd.append("--resume")
+        if target.fork:
+            cmd.append("--fork-session")
+        return cmd
+
+    if agent.name == "codex":
+        verb = "fork" if target.fork else "resume"
+        cmd = [agent.executable, verb]
+        if target.mode == "last":
+            cmd.append("--last")
+        elif target.mode == "id":
+            assert target.session_id is not None
+            cmd.append(target.session_id)
+        return cmd
+
+    raise ValueError(f"Resume is not supported for agent '{agent.name}'")
+
+
+def resume_session(target: ResumeTarget) -> None:
+    """Resume a previous coaching session, preserving FASTER system prompt where required."""
+    config = get_project_config()
+    try:
+        agent = get_agent_profile(config.get("agent", DEFAULT_AGENT))
+    except ValueError as exc:
+        print_error(str(exc))
+        sys.exit(1)
+
+    learning_mode = config.get("learning_mode", "balanced")
+    # Claude rebuilds the system prompt from CLI flags on every turn (it is not
+    # persisted in the session JSONL). We re-pass it so the resumed session keeps
+    # FASTER coaching behavior. Codex persists the original first-user-turn prompt
+    # inside the transcript, so it does not need (and must not get) re-injection.
+    system_prompt = read_system_prompt(agent, learning_mode) if agent.name == "claude-code" else ""
+
+    print_info(f"Resuming {agent.display_name} session...")
+    print_dim(f"(Mode: {target.mode}{', fork' if target.fork else ''})\n")
+
+    cmd = build_resume_command(agent, system_prompt, target)
+    _run_agent(cmd, agent)
+
+
+def _run_agent(cmd: list[str], agent: AgentProfile) -> None:
     try:
         subprocess.run(cmd, check=False)
     except FileNotFoundError:

--- a/src/learn_faster/cli/main.py
+++ b/src/learn_faster/cli/main.py
@@ -10,7 +10,7 @@ import sys
 
 from learn_faster.cli.agents import AGENT_PROFILES
 from learn_faster.cli.installer import check_initialization, init_project
-from learn_faster.cli.launcher import launch_coach
+from learn_faster.cli.launcher import ResumeTarget, launch_coach, resume_session
 from learn_faster.cli.ui import print_dim, print_error, print_header, print_info
 
 
@@ -18,11 +18,15 @@ def print_help() -> None:
     """Print CLI usage information."""
     print("Learn FASTER - Accelerate learning with FASTER framework\n")
     print("Usage:")
-    print("  learn-faster           Auto-init and launch the configured agent in coach mode")
-    print("  learn-faster init      Force re-initialization")
+    print("  learn-faster                       Auto-init and launch the configured agent in coach mode")
+    print("  learn-faster init                  Force re-initialization")
     print("  learn-faster init --agent claude-code")
     print("  learn-faster init --agent codex")
-    print("  learn-faster version   Show version")
+    print("  learn-faster resume                Continue the most recent session in this project")
+    print("  learn-faster resume <id>           Resume a specific session by id")
+    print("  learn-faster resume --pick         Open the agent's interactive session picker")
+    print("  learn-faster resume ... --fork     Fork the resumed session into a new id")
+    print("  learn-faster version               Show version")
     print()
     print(f"Supported agents: {', '.join(sorted(AGENT_PROFILES))}")
     print("For more info: https://github.com/cheukyin175/learn-faster-kit")
@@ -41,6 +45,41 @@ def parse_agent_arg(args: list[str]) -> str | None:
     sys.exit(1)
 
 
+def parse_resume_args(args: list[str]) -> ResumeTarget:
+    """Parse arguments for the resume subcommand into a ResumeTarget."""
+    pick = False
+    fork = False
+    positional: list[str] = []
+
+    for arg in args:
+        if arg == "--pick":
+            pick = True
+        elif arg == "--fork":
+            fork = True
+        elif arg.startswith("-"):
+            print_error(f"Unknown option for resume: {arg}")
+            print_dim("Usage: learn-faster resume [<id>] [--pick] [--fork]")
+            sys.exit(1)
+        else:
+            positional.append(arg)
+
+    if len(positional) > 1:
+        print_error("Resume accepts at most one session id")
+        print_dim("Usage: learn-faster resume [<id>] [--pick] [--fork]")
+        sys.exit(1)
+
+    if pick and positional:
+        print_error("--pick cannot be combined with an explicit session id")
+        print_dim("Usage: learn-faster resume [<id>] [--pick] [--fork]")
+        sys.exit(1)
+
+    if pick:
+        return ResumeTarget(mode="pick", fork=fork)
+    if positional:
+        return ResumeTarget(mode="id", session_id=positional[0], fork=fork)
+    return ResumeTarget(mode="last", fork=fork)
+
+
 def main() -> None:
     """Main CLI entry point."""
     if len(sys.argv) >= 2:
@@ -52,6 +91,13 @@ def main() -> None:
             except ValueError as exc:
                 print_error(str(exc))
                 sys.exit(1)
+            return
+        if command == "resume":
+            if not check_initialization():
+                print_error("Project is not initialized for Learn FASTER")
+                print_dim("Run 'learn-faster init' first")
+                sys.exit(1)
+            resume_session(parse_resume_args(sys.argv[2:]))
             return
         if command == "version":
             from learn_faster import __version__

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,78 @@
+"""Tests for resume command construction in learn_faster.cli.launcher."""
+
+from __future__ import annotations
+
+import pytest
+
+from learn_faster.cli.agents import get_agent_profile
+from learn_faster.cli.launcher import (
+    ResumeTarget,
+    build_resume_command,
+)
+
+
+CLAUDE = get_agent_profile("claude-code")
+CODEX = get_agent_profile("codex")
+PROMPT = "FASTER coaching system prompt"
+
+
+@pytest.mark.parametrize(
+    "target, expected_tail",
+    [
+        (ResumeTarget(mode="last"), ["--continue"]),
+        (ResumeTarget(mode="id", session_id="abc-123"), ["--resume", "abc-123"]),
+        (ResumeTarget(mode="pick"), ["--resume"]),
+        (ResumeTarget(mode="last", fork=True), ["--continue", "--fork-session"]),
+        (
+            ResumeTarget(mode="id", session_id="abc-123", fork=True),
+            ["--resume", "abc-123", "--fork-session"],
+        ),
+        (ResumeTarget(mode="pick", fork=True), ["--resume", "--fork-session"]),
+    ],
+)
+def test_claude_resume_command_shape(target: ResumeTarget, expected_tail: list[str]) -> None:
+    cmd = build_resume_command(CLAUDE, PROMPT, target)
+    assert cmd[:3] == ["claude", "--system-prompt", PROMPT]
+    assert cmd[3:] == expected_tail
+
+
+def test_claude_resume_never_includes_review() -> None:
+    for target in [
+        ResumeTarget(mode="last"),
+        ResumeTarget(mode="id", session_id="x"),
+        ResumeTarget(mode="pick"),
+        ResumeTarget(mode="last", fork=True),
+    ]:
+        cmd = build_resume_command(CLAUDE, PROMPT, target)
+        assert "/review" not in cmd
+
+
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        (ResumeTarget(mode="last"), ["codex", "resume", "--last"]),
+        (ResumeTarget(mode="id", session_id="abc-123"), ["codex", "resume", "abc-123"]),
+        (ResumeTarget(mode="pick"), ["codex", "resume"]),
+        (ResumeTarget(mode="last", fork=True), ["codex", "fork", "--last"]),
+        (
+            ResumeTarget(mode="id", session_id="abc-123", fork=True),
+            ["codex", "fork", "abc-123"],
+        ),
+        (ResumeTarget(mode="pick", fork=True), ["codex", "fork"]),
+    ],
+)
+def test_codex_resume_command_shape(target: ResumeTarget, expected: list[str]) -> None:
+    cmd = build_resume_command(CODEX, PROMPT, target)
+    assert cmd == expected
+
+
+def test_codex_resume_does_not_inject_prompt() -> None:
+    for target in [
+        ResumeTarget(mode="last"),
+        ResumeTarget(mode="id", session_id="x"),
+        ResumeTarget(mode="pick"),
+        ResumeTarget(mode="last", fork=True),
+    ]:
+        cmd = build_resume_command(CODEX, PROMPT, target)
+        assert PROMPT not in cmd
+        assert "--system-prompt" not in cmd

--- a/tests/test_main_parsing.py
+++ b/tests/test_main_parsing.py
@@ -1,0 +1,49 @@
+"""Tests for resume argument parsing in learn_faster.cli.main."""
+
+from __future__ import annotations
+
+import pytest
+
+from learn_faster.cli.launcher import ResumeTarget
+from learn_faster.cli.main import parse_resume_args
+
+
+def test_parse_resume_no_args_means_last() -> None:
+    assert parse_resume_args([]) == ResumeTarget(mode="last")
+
+
+def test_parse_resume_with_id() -> None:
+    assert parse_resume_args(["abc-123"]) == ResumeTarget(mode="id", session_id="abc-123")
+
+
+def test_parse_resume_pick() -> None:
+    assert parse_resume_args(["--pick"]) == ResumeTarget(mode="pick")
+
+
+def test_parse_resume_fork_alone() -> None:
+    assert parse_resume_args(["--fork"]) == ResumeTarget(mode="last", fork=True)
+
+
+def test_parse_resume_id_with_fork() -> None:
+    assert parse_resume_args(["abc-123", "--fork"]) == ResumeTarget(
+        mode="id", session_id="abc-123", fork=True
+    )
+
+
+def test_parse_resume_pick_with_fork() -> None:
+    assert parse_resume_args(["--pick", "--fork"]) == ResumeTarget(mode="pick", fork=True)
+
+
+def test_parse_resume_pick_with_id_errors() -> None:
+    with pytest.raises(SystemExit):
+        parse_resume_args(["--pick", "abc-123"])
+
+
+def test_parse_resume_multiple_ids_errors() -> None:
+    with pytest.raises(SystemExit):
+        parse_resume_args(["abc-123", "def-456"])
+
+
+def test_parse_resume_unknown_flag_errors() -> None:
+    with pytest.raises(SystemExit):
+        parse_resume_args(["--bogus"])

--- a/uv.lock
+++ b/uv.lock
@@ -98,6 +98,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "editor"
 version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
@@ -108,6 +117,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/92/734a4ab345914259cb6146fd36512608ea42be16195375c379046f33283d/editor-1.6.6.tar.gz", hash = "sha256:bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8", size = 3197, upload-time = "2024-01-25T10:44:59.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/c2/4bc8cd09b14e28ce3f406a8b05761bed0d785d1ca8c2a5c6684d884c66a2/editor-1.6.6-py3-none-any.whl", hash = "sha256:e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf", size = 4017, upload-time = "2024-01-25T10:44:58.66Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -145,6 +163,11 @@ dependencies = [
     { name = "reportlab" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "inquirer", specifier = ">=3.1.0" },
@@ -152,7 +175,16 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
 
 [[package]]
 name = "pillow"
@@ -221,6 +253,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #6

## Problem

`learn-faster` had no resume path: every invocation launched a fresh agent process. A user who fell back to `claude --continue` would see the transcript restored but the FASTER system prompt silently dropped on the next turn, because Claude Code rebuilds its system prompt from the current CLI flags on every turn and does not persist it with the session. Codex behaves asymmetrically: the FASTER system prompt was
injected as the first user turn at session creation, so it is replayed from the transcript on `codex resume`.

## Approach

A new `resume` subcommand mirrors the underlying agents one-to-one:

| Invocation                     | Behavior                                          |
| ------------------------------ | ------------------------------------------------- |
| `learn-faster resume`          | Continue the most recent session in this project  |
| `learn-faster resume <id>`     | Resume a specific session by id                   |
| `learn-faster resume --pick`   | Open the agent's interactive session picker       |
| `... --fork`                   | Fork the resumed session into a new id            |

The launcher dispatches on the existing `AgentProfile.launch_style` seam:

- Claude Code branch: builds `["claude", "--system-prompt", <prompt>, "--continue" | "--resume" [id]]` plus `"--fork-session"` when requested. The `--system-prompt` flag is re-passed on every resume so coaching behavior is preserved.
- Codex branch: builds `["codex", "resume" | "fork", "--last" | <id>]` (no argument means picker). No prompt is injected; the transcript already carries it.

A pure helper `build_resume_command()` constructs the command list, which keeps the unit tests free of subprocess mocking.

## Changes

- `src/learn_faster/cli/launcher.py`: `ResumeTarget` dataclass, `build_resume_command()` (pure), `resume_session()`, factored `_run_agent()`.
- `src/learn_faster/cli/main.py`: `resume` subcommand, `parse_resume_args()`, refreshed `print_help()`.
- `tests/test_launcher.py`, `tests/test_main_parsing.py`: 23 tests covering both agents across `{last, id, pick}` and `{fork on/off}`, the `/review`-not-injected guard for Claude resume, the prompt-not-injected guard for Codex resume, and every parser error path.
- `pyproject.toml`: dev-dependencies moved to the modern `[dependency-groups] dev` key so `pytest>=8.0` installs cleanly. No version bump; release-please owns versioning.
- `README.md`: one CLI-table line for the new command.