### PR TITLE
Fix launch failure: split `plan_mode_cmd` into separate argv tokens

### DIFF
--- a/src/learn_faster/cli/launcher.py
+++ b/src/learn_faster/cli/launcher.py
@@ -85,7 +85,7 @@ def launch_coach(auto_review: bool = False, initialize: bool = False) -> None:
     if agent.launch_style == "system-prompt":
         cmd = [agent.executable, "--system-prompt", system_prompt]
         if initialize:
-            cmd.append(agent.plan_mode_cmd)
+            cmd.extend(agent.plan_mode_cmd.split())
         if auto_review:
             cmd.extend(["/review"])
     elif agent.launch_style == "prompt":


### PR DESCRIPTION
Fixes #8.

## Problem

Launching the coach in initialize/plan mode fails immediately:

```
error: unknown option '--permission-mode plan'
```

`plan_mode_cmd` is stored as a single space-separated string (`"--permission-mode plan"`) in `agents.py`, but `launcher.py` appended it as a single list element. Since `_run_agent` calls `subprocess.run(cmd, check=False)` with a list (no shell), that whole string becomes one argv token, so the agent receives an option literally named `--permission-mode plan` and rejects it.

## Fix

```diff
-            cmd.append(agent.plan_mode_cmd)
+            cmd.extend(agent.plan_mode_cmd.split())
```

`str.split()` turns it into two proper argv tokens (`--permission-mode`, `plan`). This also fixes the same latent bug for the codex profile (`--enable collaboration_modes`).

## Testing

- `--permission-mode plan` is a valid Claude Code flag when passed as two tokens; the launch now succeeds instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)